### PR TITLE
Fix Incorrect use of ParentDataWidget exception

### DIFF
--- a/Chapter_05/lib/flex_screen.dart
+++ b/Chapter_05/lib/flex_screen.dart
@@ -19,7 +19,7 @@ class FlexScreen extends StatelessWidget {
             ..._header(context, 'Flexible'),
             const DemoFlexible(),
             const Expanded(
-              child: Spacer(),
+              child: Container(),
             ),
             const DemoFooter()
           ],


### PR DESCRIPTION
### Issue

Currently `flex_screen.dart` throws an exception

```code
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following assertion was thrown while looking for parent data.:
Incorrect use of ParentDataWidget.
The following ParentDataWidgets are providing parent data to the same RenderObject:
- Expanded(flex: 1) (typically placed directly inside a Flex widget)
- Expanded(flex: 1) (typically placed directly inside a Flex widget)
However, a RenderObject can only receive parent data from at most one ParentDataWidget.
Usually, this indicates that at least one of the offending ParentDataWidgets listed above is not
placed directly inside a compatible ancestor widget.
The ownership chain for the RenderObject that received the parent data was:
  SizedBox.shrink ← Expanded ← Spacer ← Expanded ← Column ← MediaQuery ← Padding ← SafeArea ←
KeyedSubtree-[GlobalKey#0e139] ← _BodyBuilder ← ⋯
```

### Solution

Spacer() should not be used in Expanded(). Container() should be used instead.