### PR TITLE
Handle edge case where form.validate() evaluates to null

### DIFF
--- a/Chapter_06/lib/login_screen.dart
+++ b/Chapter_06/lib/login_screen.dart
@@ -68,7 +68,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
   void _validate() {
     final form = _formKey.currentState;
-    if (form?.validate() == false) {
+    if (!(form?.validate() ?? false)) {
       return;
     }
 


### PR DESCRIPTION
If `form?.validate()` evaluates to null, then `form?.validate() == false` evaluates to false, which will erroneously trigger login even though no validation was done.